### PR TITLE
Enhance APIs, services, and repositories for presets

### DIFF
--- a/MamaFit.API/Controllers/ComponentController.cs
+++ b/MamaFit.API/Controllers/ComponentController.cs
@@ -27,7 +27,8 @@ namespace MamaFit.API.Controllers
             return Ok(new ResponseModel<PaginatedList<ComponentResponseDto>>(
                 StatusCodes.Status200OK,
                 ApiCodes.SUCCESS,
-                components
+                components,
+                "Get all components successfully!"
             ));
         }
 
@@ -35,29 +36,60 @@ namespace MamaFit.API.Controllers
         public async Task<IActionResult> GetById([FromRoute] string componentId)
         {
             var component = await _componentService.GetByIdAsync(componentId);
-            return Ok(ResponseModel<ComponentGetByIdResponseDto>.OkResponseModel(component));
+            return Ok(new ResponseModel<ComponentGetByIdResponseDto>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                component,
+                "Get component successfully!"
+                ));
+        }
+
+        [HttpGet("preset/style/{styleId}")]
+        public async Task<IActionResult> GetAllByStyleId([FromRoute] string styleId)
+        {
+            var components = await _componentService.GetComponentHavePresetByStyleId(styleId);
+            return Ok(new ResponseModel<List<ComponentGetByIdResponseDto>>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                components,
+                "Get all components by style ID successfully!"
+                ));
         }
 
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] ComponentRequestDto requestDto)
         {
             await _componentService.CreateAsync(requestDto);
-            return StatusCode(StatusCodes.Status201Created,
-                ResponseModel<string>.CreatedResponseModel("Created successfully"));
+            return Ok(new ResponseModel<string>(
+                StatusCodes.Status201Created,
+                ApiCodes.SUCCESS,
+                "Component created successfully",
+                "Created successfully"
+            ));
         }
 
         [HttpPut("{componentId}")]
         public async Task<IActionResult> Update(string componentId, [FromBody] ComponentRequestDto requestDto)
         {
             await _componentService.UpdateAsync(componentId, requestDto);
-            return Ok(ResponseModel<string>.OkResponseModel("Updated successfully"));
+            return Ok(new ResponseModel<string>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                "Component updated successfully",
+                "Updated successfully"
+            ));
         }
 
         [HttpDelete("{componentId}")]
         public async Task<IActionResult> Delete(string componentId)
         {
             await _componentService.DeleteAsync(componentId);
-            return Ok(ResponseModel<string>.OkResponseModel("Deleted successfully"));
+            return Ok(new ResponseModel<string>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                "Component deleted successfully",
+                "Deleted successfully"
+            ));
         }
     }
 }

--- a/MamaFit.API/Controllers/PresetController.cs
+++ b/MamaFit.API/Controllers/PresetController.cs
@@ -41,6 +41,30 @@ namespace MamaFit.API.Controllers
             ));
         }
 
+        [HttpGet("default/{styleId}")]
+        public async Task<IActionResult> GetDefaultPresetByStyleId([FromRoute] string styleId)
+        {
+            var preset = await _presetService.GetDefaultPresetByStyleId(styleId);
+            return Ok(new ResponseModel<PresetGetByIdResponseDto>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                preset,
+                "Get default preset by style ID successfully!"
+            ));
+        }
+
+        [HttpPost("component-option")]
+        public async Task<IActionResult> GetAllPresetByComponentOptionId([FromBody] List<string> componentOptionId)
+        {
+            var presets = await _presetService.GetAllPresetByComponentOptionId(componentOptionId);
+            return Ok(new ResponseModel<List<PresetGetAllResponseDto>>(
+                StatusCodes.Status200OK,
+                ApiCodes.SUCCESS,
+                presets,
+                "Get all presets by component option ID successfully!"
+            ));
+        }
+
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] PresetCreateRequestDto requestDto)
         {

--- a/MamaFit.BusinessObjects/DTO/PresetDto/PresetGetAllResponseDto.cs
+++ b/MamaFit.BusinessObjects/DTO/PresetDto/PresetGetAllResponseDto.cs
@@ -3,6 +3,8 @@
     public class PresetGetAllResponseDto : PresetBaseRequestDto
     {
         public string Id { get; set; } 
+        public string? StyleId { get; set; }
+        public string? StyleName { get; set; }
         public DateTime CreatedAt { get; set; }
         public string CreatedBy { get; set; } = string.Empty;
         public DateTime UpdatedAt { get; set; }

--- a/MamaFit.Repositories/Interface/IComponentRepository.cs
+++ b/MamaFit.Repositories/Interface/IComponentRepository.cs
@@ -8,5 +8,6 @@ namespace MamaFit.Repositories.Interface
     {
         Task<PaginatedList<Component>> GetAllAsync(int index, int pageSize, string? search, string? sortBy);
         Task<Component> GetById(string id);
+        Task<List<Component>> GetComponentHavePresetByStyleId(string styleId);
     }
 }

--- a/MamaFit.Repositories/Interface/IPresetRepository.cs
+++ b/MamaFit.Repositories/Interface/IPresetRepository.cs
@@ -9,5 +9,7 @@ namespace MamaFit.Repositories.Interface
     {
         public Task<PaginatedList<Preset>> GetAll(int index, int pageSize, string? search, EntitySortBy? sortBy);
         public Task<Preset> GetDetailById(string id);
+        public Task<Preset> GetDefaultPresetByStyleId(string styleId);
+        public Task<List<Preset>> GetAllPresetByComponentOptionId(List<string> componentOptionId);
     }
 }

--- a/MamaFit.Repositories/Repository/ComponentRepository.cs
+++ b/MamaFit.Repositories/Repository/ComponentRepository.cs
@@ -1,15 +1,9 @@
-﻿using MamaFit.BusinessObjects.DTO.ComponentDto;
-using MamaFit.BusinessObjects.Entity;
+﻿using MamaFit.BusinessObjects.Entity;
 using MamaFit.Repositories.Implement;
 using MamaFit.Repositories.Infrastructure;
 using MamaFit.Repositories.Interface;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using MamaFit.BusinessObjects.DbContext;
 
 namespace MamaFit.Repositories.Repository
@@ -59,6 +53,22 @@ namespace MamaFit.Repositories.Repository
                 .Where(c => !c.IsDeleted)
                 .FirstOrDefaultAsync(c => c.Id.Equals(id));
             return component!;
+        }
+
+        public async Task<List<Component>> GetComponentHavePresetByStyleId(string styleId)
+        {
+            var component = await _dbSet
+                .Include(c => c.Options)
+                .ThenInclude(co => co.Presets)
+                .ThenInclude(p => p.ComponentOptions)
+                .Where(c => !c.IsDeleted &&
+                    c.Options.Any(co => 
+                        co.Presets.Any(p => 
+                            p.ComponentOptions.Any(pco => 
+                                pco.Id.Equals(co.Id)))))
+                .ToListAsync();
+
+            return component;
         }
     }
 }

--- a/MamaFit.Repositories/Repository/PresetRepository.cs
+++ b/MamaFit.Repositories/Repository/PresetRepository.cs
@@ -18,6 +18,7 @@ namespace MamaFit.Repositories.Repository
         public async Task<PaginatedList<Preset>> GetAll(int index, int pageSize, string? search, EntitySortBy? sortBy)
         {
             var query = _dbSet
+                .Include(p => p.Style)
                 .Where(x => !x.IsDeleted);
 
             if (!string.IsNullOrWhiteSpace(search))
@@ -39,11 +40,32 @@ namespace MamaFit.Repositories.Repository
             return new PaginatedList<Preset>(list, paged.TotalCount, paged.PageNumber, pageSize);
         }
 
+        public async Task<List<Preset>> GetAllPresetByComponentOptionId(List<string> componentOptionId)
+        {
+           var preset = await _dbSet
+                .Include(x => x.ComponentOptions)
+                .Where(x => x.ComponentOptions.Any(co => componentOptionId.Contains(co.Id)) && !x.IsDeleted)
+                .ToListAsync();
+
+            return preset;
+        }
+
+        public async Task<Preset> GetDefaultPresetByStyleId(string styleId)
+        {
+            var preset = await _dbSet
+                .Include(x => x.ComponentOptions)
+                .Include(x => x.Style)
+                .FirstOrDefaultAsync(x => x.StyleId == styleId && x.IsDefault && !x.IsDeleted && x.IsDefault);
+
+            return preset;
+        }
+
         public async Task<Preset> GetDetailById(string id)
         {
             var result = await _dbSet
                 .Include(x => x.ComponentOptions)
                 .Include(x => x.OrderItems)
+                .Include(x => x.Style)
                 .FirstOrDefaultAsync(x => x.Id == id && !x.IsDeleted);
 
             return result;

--- a/MamaFit.Services/Interface/IComponentService.cs
+++ b/MamaFit.Services/Interface/IComponentService.cs
@@ -7,6 +7,7 @@ namespace MamaFit.Services.Interface
     {
         Task<ComponentGetByIdResponseDto> GetByIdAsync(string id);
         Task<PaginatedList<ComponentResponseDto>> GetAllAsync(int index, int pageSize, string? search, string? sortBy);
+        Task<List<ComponentGetByIdResponseDto>> GetComponentHavePresetByStyleId(string styleId);
         Task CreateAsync(ComponentRequestDto requestDto);
         Task UpdateAsync(string id, ComponentRequestDto requestDto);
         Task DeleteAsync(string id);

--- a/MamaFit.Services/Interface/IPresetService.cs
+++ b/MamaFit.Services/Interface/IPresetService.cs
@@ -8,6 +8,8 @@ namespace MamaFit.Services.Interface
     {
         Task<PaginatedList<PresetGetAllResponseDto>> GetAll(int index, int pageSize, string? search, EntitySortBy? sortBy);
         Task<PresetGetByIdResponseDto> GetById(string id);
+        public Task<PresetGetByIdResponseDto> GetDefaultPresetByStyleId(string styleId);
+        public Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionId);
         Task CreatePresetAsync(PresetCreateRequestDto request);
         Task UpdatePresetAsync(string id, PresetUpdateRequestDto request);
         Task DeletePresetAsync(string id);

--- a/MamaFit.Services/Mapper/MapperEntities.cs
+++ b/MamaFit.Services/Mapper/MapperEntities.cs
@@ -210,7 +210,9 @@ namespace MamaFit.Services.Mapper
             //Preset Mapper
             CreateMap<Preset, PresetCreateRequestDto>().ReverseMap();
             CreateMap<Preset, PresetUpdateRequestDto>().ReverseMap();
-            CreateMap<Preset, PresetGetAllResponseDto>().ReverseMap();
+            CreateMap<Preset, PresetGetAllResponseDto>()
+                .ForMember(dest => dest.StyleName, otp => otp.MapFrom(src => src.Style!.Name))
+                .ReverseMap();
             CreateMap<Preset, PresetGetByIdResponseDto>().ReverseMap();
         }
     }

--- a/MamaFit.Services/Service/ComponentService.cs
+++ b/MamaFit.Services/Service/ComponentService.cs
@@ -76,6 +76,16 @@ namespace MamaFit.Services.Service
             return _mapper.Map<ComponentGetByIdResponseDto>(component);
         }
 
+        public async Task<List<ComponentGetByIdResponseDto>> GetComponentHavePresetByStyleId(string styleId)
+        {
+            var style = await _unitOfWork.StyleRepository.GetByIdNotDeletedAsync(styleId);
+            _validation.CheckNotFound(style, $"Style with ID {styleId} not found.");
+
+            var components = await _unitOfWork.ComponentRepository.GetComponentHavePresetByStyleId(styleId);
+            _validation.CheckNotFound(components, $"No components found for style with ID {styleId}.");
+            return components.Select(c => _mapper.Map<ComponentGetByIdResponseDto>(c)).ToList();
+        }
+
         public async Task UpdateAsync(string id, ComponentRequestDto requestDto)
         {
             await _validation.ValidateAndThrowAsync(requestDto);

--- a/MamaFit.Services/Service/PresetService.cs
+++ b/MamaFit.Services/Service/PresetService.cs
@@ -96,5 +96,25 @@ namespace MamaFit.Services.Service
             await _unitOfWork.PresetRepository.UpdateAsync(preset);
             await _unitOfWork.SaveChangesAsync();
         }
+
+        public async Task<PresetGetByIdResponseDto> GetDefaultPresetByStyleId(string styleId)
+        {
+            var style = await _unitOfWork.StyleRepository.GetByIdNotDeletedAsync(styleId);
+            _validationService.CheckNotFound(style, $"Style with ID {styleId} not found.");
+
+            var preset = await _unitOfWork.PresetRepository.GetDefaultPresetByStyleId(styleId);
+            _validationService.CheckNotFound(preset, $"Default preset for style with ID {styleId} not found.");
+            return _mapper.Map<PresetGetByIdResponseDto>(preset);
+        }
+
+        public async Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionId)
+        {
+            var componentOption = await _unitOfWork.ComponentOptionRepository.GetByIdNotDeletedAsync(componentOptionId);
+            _validationService.CheckNotFound(componentOption, $"Component option with ID {componentOptionId} not found.");
+
+            var presets = await _unitOfWork.PresetRepository.GetAllPresetByComponentOptionId(componentOptionId);
+            _validationService.CheckNotFound(presets, $"No presets found for component option with ID {componentOptionId}.");
+            return presets.Select(preset => _mapper.Map<PresetGetAllResponseDto>(preset)).ToList();
+        }
     }
 }


### PR DESCRIPTION
- Added new endpoints in `ComponentController` and `PresetController` for fetching components and presets by style ID and component option IDs.
- Updated `PresetGetAllResponseDto` to include `StyleId` and `StyleName`.
- Extended and implemented repository methods in `IComponentRepository` and `IPresetRepository` for preset-related queries.
- Added and implemented service methods in `IComponentService` and `IPresetService` with validation for related entities.
- Enhanced AutoMapper configurations to map `StyleName` in `PresetGetAllResponseDto`.
- Refactored response models for consistent structure with status codes and messages.
- Improved validation, error handling, and code readability.