### PR TITLE
Update preset retrieval by multiple component option IDs

### DIFF
--- a/MamaFit.Repositories/Repository/PresetRepository.cs
+++ b/MamaFit.Repositories/Repository/PresetRepository.cs
@@ -42,12 +42,14 @@ namespace MamaFit.Repositories.Repository
 
         public async Task<List<Preset>> GetAllPresetByComponentOptionId(List<string> componentOptionId)
         {
-           var preset = await _dbSet
+            var presets = await _dbSet
                 .Include(x => x.ComponentOptions)
-                .Where(x => x.ComponentOptions.Any(co => componentOptionId.Contains(co.Id)) && !x.IsDeleted)
+                .Include(x => x.Style)
+                .Where(p => !p.IsDeleted &&
+                     componentOptionId.All(id => p.ComponentOptions.Any(co => co.Id == id)))
                 .ToListAsync();
 
-            return preset;
+            return presets;
         }
 
         public async Task<Preset> GetDefaultPresetByStyleId(string styleId)

--- a/MamaFit.Services/Interface/IPresetService.cs
+++ b/MamaFit.Services/Interface/IPresetService.cs
@@ -9,7 +9,7 @@ namespace MamaFit.Services.Interface
         Task<PaginatedList<PresetGetAllResponseDto>> GetAll(int index, int pageSize, string? search, EntitySortBy? sortBy);
         Task<PresetGetByIdResponseDto> GetById(string id);
         public Task<PresetGetByIdResponseDto> GetDefaultPresetByStyleId(string styleId);
-        public Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionId);
+        public Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionIds);
         Task CreatePresetAsync(PresetCreateRequestDto request);
         Task UpdatePresetAsync(string id, PresetUpdateRequestDto request);
         Task DeletePresetAsync(string id);

--- a/MamaFit.Services/Service/PresetService.cs
+++ b/MamaFit.Services/Service/PresetService.cs
@@ -107,13 +107,17 @@ namespace MamaFit.Services.Service
             return _mapper.Map<PresetGetByIdResponseDto>(preset);
         }
 
-        public async Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionId)
+        public async Task<List<PresetGetAllResponseDto>> GetAllPresetByComponentOptionId(List<string> componentOptionIds)
         {
-            var componentOption = await _unitOfWork.ComponentOptionRepository.GetByIdNotDeletedAsync(componentOptionId);
-            _validationService.CheckNotFound(componentOption, $"Component option with ID {componentOptionId} not found.");
 
-            var presets = await _unitOfWork.PresetRepository.GetAllPresetByComponentOptionId(componentOptionId);
-            _validationService.CheckNotFound(presets, $"No presets found for component option with ID {componentOptionId}.");
+            foreach(var componentOptionId in componentOptionIds)
+            {
+                var componentOption = await _unitOfWork.ComponentOptionRepository.GetByIdNotDeletedAsync(componentOptionId);
+                _validationService.CheckNotFound(componentOption, $"Component option with ID {componentOptionId} not found.");
+            }
+
+            var presets = await _unitOfWork.PresetRepository.GetAllPresetByComponentOptionId(componentOptionIds);
+            _validationService.CheckNotFound(presets, $"No presets found for component option with ID {componentOptionIds}.");
             return presets.Select(preset => _mapper.Map<PresetGetAllResponseDto>(preset)).ToList();
         }
     }


### PR DESCRIPTION
Refactored methods to accept and process a list of component option IDs when retrieving presets. The repository and service logic now ensure all provided IDs are matched, and validation is performed for each ID. Parameter names were updated for clarity.