### PR TITLE
Add API for order item task status management

### DIFF
--- a/MamaFit.API/Controllers/OrderItemController.cs
+++ b/MamaFit.API/Controllers/OrderItemController.cs
@@ -92,6 +92,18 @@ public class OrderItemController : ControllerBase
         ));
     }
 
+    [HttpPost("check-list-status")]
+    public async Task<IActionResult> CheckListStatusForOrderItemTask([FromBody] OrderItemCheckTaskRequestDto request)
+    {
+        await _service.CheckListStatusForOrderItemTaskAsync(request);
+        return Ok(new ResponseModel<string>(
+            StatusCodes.Status200OK,
+            ApiCodes.SUCCESS,
+            null,
+            "Check list status for order item task successfully!"
+        ));
+    }
+
     [HttpDelete("{id}")]
     public async Task<IActionResult> Delete([FromRoute] string id)
     {

--- a/MamaFit.API/DependencyInjection/ApplicationServiceExtension.cs
+++ b/MamaFit.API/DependencyInjection/ApplicationServiceExtension.cs
@@ -68,7 +68,7 @@ namespace MamaFit.API.DependencyInjection
             services.AddScoped<IPresetRepository, PresetRepository>();
             services.AddScoped<IWarrantyRequestRepository, WarrantyRequestRepository>();
             services.AddScoped<IMaternityDressServiceRepository, MaternityDressServiceRepository>();
-        }
+            services.AddScoped<IOrderItemTaskRepository, OrderItemTaskRepository>();        }
 
         public static void AddServices(this IServiceCollection services)
         {

--- a/MamaFit.BusinessObjects/DTO/OrderItemDto/ChargeDesginerToOrderItemTaskRequestDto.cs
+++ b/MamaFit.BusinessObjects/DTO/OrderItemDto/ChargeDesginerToOrderItemTaskRequestDto.cs
@@ -1,7 +1,0 @@
-﻿namespace MamaFit.BusinessObjects.DTO.OrderItemDto
-{
-    public class ChargeDesginerToOrderItemTaskRequestDto
-    {
-
-    }
-}

--- a/MamaFit.BusinessObjects/DTO/OrderItemDto/OrderItemCheckTaskRequestDto.cs
+++ b/MamaFit.BusinessObjects/DTO/OrderItemDto/OrderItemCheckTaskRequestDto.cs
@@ -1,0 +1,11 @@
+﻿using MamaFit.BusinessObjects.Enum;
+
+namespace MamaFit.BusinessObjects.DTO.OrderItemDto
+{
+    public class OrderItemCheckTaskRequestDto
+    {
+        public List<string>? MaternityDressTaskIds { get; set; }
+        public string? OrderItemId { get; set; }
+        public OrderItemTaskStatus Status { get; set; }
+    }
+}

--- a/MamaFit.BusinessObjects/DTO/OrderItemTaskDto/OrderItemTaskGetDetail.cs
+++ b/MamaFit.BusinessObjects/DTO/OrderItemTaskDto/OrderItemTaskGetDetail.cs
@@ -1,0 +1,8 @@
+﻿namespace MamaFit.BusinessObjects.DTO.OrderItemTaskDto
+{
+    public class OrderItemTaskGetDetail
+    {
+        public string? OrderItemId { get; set; }
+        public string? MaternityDressTaskId { get; set; }
+    }
+}

--- a/MamaFit.BusinessObjects/Entity/Order.cs
+++ b/MamaFit.BusinessObjects/Entity/Order.cs
@@ -17,7 +17,7 @@ namespace MamaFit.BusinessObjects.Entity
         public OrderStatus? Status { get; set; }
         public decimal? TotalAmount { get; set; }
         public decimal ShippingFee { get; set; }
-        public decimal? DiscountSubtotal { get; set; } 
+        public decimal? DiscountSubtotal { get; set; }
         public decimal? DepositSubtotal { get; set; }
         public decimal? RemainingBalance { get; set; }
         public PaymentStatus PaymentStatus { get; set; }
@@ -26,7 +26,7 @@ namespace MamaFit.BusinessObjects.Entity
         public PaymentType PaymentType { get; set; }
         public DateTime? CanceledAt { get; set; }
         public string? CanceledReason { get; set; }
-        public decimal? SubTotalAmount { get; set; } //gốc
+        public decimal? SubTotalAmount { get; set; } 
         public string? WarrantyCode { get; set; }
 
         // Navigation properties

--- a/MamaFit.Repositories/Implement/IUnitOfWork.cs
+++ b/MamaFit.Repositories/Implement/IUnitOfWork.cs
@@ -35,6 +35,7 @@ namespace MamaFit.Repositories.Implement
         public ICartItemRepository CartItemRepository { get; }
         public IPresetRepository PresetRepository { get; }
         public IMaternityDressServiceRepository MaternityDressServiceRepository { get; }
+        public IOrderItemTaskRepository OrderItemTaskRepository { get; }
         int SaveChanges();
         Task<int> SaveChangesAsync();
         void BeginTransaction();

--- a/MamaFit.Repositories/Implement/UnitOfWork.cs
+++ b/MamaFit.Repositories/Implement/UnitOfWork.cs
@@ -39,6 +39,8 @@ namespace MamaFit.Repositories.Implement
         public IPresetRepository PresetRepository { get; }
         public IMaternityDressServiceRepository MaternityDressServiceRepository { get; }
 
+        public IOrderItemTaskRepository OrderItemTaskRepository { get; }
+
         public UnitOfWork(ApplicationDbContext context,
             IUserRepository userRepository,
             IAddressRepository addressRepository,
@@ -70,7 +72,8 @@ namespace MamaFit.Repositories.Implement
             ICartItemRepository cartItemRepository,
             IPresetRepository presetRepository,
             IWarrantyRequestRepository warrantyRequestRepository,
-            IMaternityDressServiceRepository maternityDressServiceRepository)
+            IMaternityDressServiceRepository maternityDressServiceRepository,
+            IOrderItemTaskRepository orderItemTaskRepository)
         {
             _context = context;
             UserRepository = userRepository;
@@ -104,6 +107,7 @@ namespace MamaFit.Repositories.Implement
             PresetRepository = presetRepository;
             WarrantyRequestRepository = warrantyRequestRepository;
             MaternityDressServiceRepository = maternityDressServiceRepository;
+            OrderItemTaskRepository = orderItemTaskRepository;
         }
 
         public int SaveChanges()

--- a/MamaFit.Repositories/Interface/IOrderItemTaskRepository.cs
+++ b/MamaFit.Repositories/Interface/IOrderItemTaskRepository.cs
@@ -1,0 +1,12 @@
+﻿using MamaFit.BusinessObjects.DTO.OrderItemTaskDto;
+using MamaFit.BusinessObjects.Entity;
+using MamaFit.BusinessObjects.Enum;
+
+namespace MamaFit.Repositories.Interface
+{
+    public interface IOrderItemTaskRepository 
+    {
+        Task<OrderItemTask> GetDetailAsync(OrderItemTaskGetDetail request);
+        Task UpdateOrderItemTaskStatusAsync(OrderItemTask task, OrderItemTaskStatus status);
+    }
+}

--- a/MamaFit.Repositories/Repository/OrderItemTaskRepository.cs
+++ b/MamaFit.Repositories/Repository/OrderItemTaskRepository.cs
@@ -1,0 +1,50 @@
+﻿using MamaFit.BusinessObjects.DbContext;
+using MamaFit.BusinessObjects.DTO.OrderItemTaskDto;
+using MamaFit.BusinessObjects.Entity;
+using MamaFit.BusinessObjects.Enum;
+using MamaFit.Repositories.Interface;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace MamaFit.Repositories.Repository
+{
+    public class OrderItemTaskRepository : IOrderItemTaskRepository
+    {
+        private readonly ApplicationDbContext _context;
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        public OrderItemTaskRepository(ApplicationDbContext context, IHttpContextAccessor httpContextAccessor)
+        {
+            _context = context;
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        public async Task<OrderItemTask> GetDetailAsync(OrderItemTaskGetDetail request)
+        {
+            var orderItemTask = await _context.OrderItemsTasks.
+                Include(x => x.User).
+                Include(x => x.MaternityDressTask).
+                Include(x => x.OrderItem).
+                FirstOrDefaultAsync(x => x.OrderItemId.Equals(request.OrderItemId)
+                && x.MaternityDressTaskId.Equals(request.MaternityDressTaskId));
+
+            return orderItemTask;
+        }
+
+        public async Task UpdateOrderItemTaskStatusAsync(OrderItemTask task, OrderItemTaskStatus status)
+        {
+            task.Status = status;
+            task.UpdatedBy = GetCurrentUserName();
+            task.UpdatedAt = DateTime.UtcNow;
+
+            _context.Entry(task).State = EntityState.Modified;
+            await _context.SaveChangesAsync();
+        }
+
+        private string GetCurrentUserName()
+        {
+            var username = _httpContextAccessor.HttpContext?.User?.FindFirst("userName")?.Value;
+            return username ?? "System";
+        }
+    }
+}

--- a/MamaFit.Services/Interface/IOrderItemService.cs
+++ b/MamaFit.Services/Interface/IOrderItemService.cs
@@ -14,4 +14,5 @@ public interface IOrderItemService
     Task DeleteOrderItemAsync(string id);
     Task AssignTaskToOrderItemAsync(AssignTaskToOrderItemRequestDto request);
     Task AssignChargeToOrderItemAsync(AssignChargeToOrderItemRequestDto request);
+    Task CheckListStatusForOrderItemTaskAsync(OrderItemCheckTaskRequestDto request);
 }


### PR DESCRIPTION
Introduced a new `POST` endpoint `check-list-status` in `OrderItemController.cs` to check and update the status of order item tasks. Added supporting service methods, repository interfaces, and DTOs (`OrderItemCheckTaskRequestDto`, `OrderItemTaskGetDetail`) for seamless integration. Registered `IOrderItemTaskRepository` in DI and updated `UnitOfWork` and `OrderItemService` accordingly. Removed unused `ChargeDesginerToOrderItemTaskRequestDto.cs`.