### PR TITLE
fix: appointment get

### DIFF
--- a/MamaFit.Repositories/Repository/AppointmentRepository.cs
+++ b/MamaFit.Repositories/Repository/AppointmentRepository.cs
@@ -86,7 +86,7 @@ namespace MamaFit.Repositories.Repository
 
         public async Task<List<AppointmentSlotResponseDto>> GetSlot(Branch branch, DateOnly date, TimeSpan slotInterval)
         {
-            var dateTime = date.ToDateTime(TimeOnly.MinValue);
+            var dateTime = date.ToDateTime(TimeOnly.MaxValue).ToUniversalTime();
 
             var bookedSlots = await _dbSet
                 .AsNoTracking()
@@ -106,7 +106,7 @@ namespace MamaFit.Repositories.Repository
                 var slotEnd = currentTime.Add(slotInterval);
 
                 // Kiểm tra xem slotStart đã được đặt chưa
-                bool isBooked = bookedSlots.Contains(slotStart);
+                bool isBooked = bookedSlots.Any(b => b >= slotStart && b < slotEnd);
 
                 slots.Add(new AppointmentSlotResponseDto
                 {


### PR DESCRIPTION
Optimize slot management with caching and time handling

Updated `GetSlot` method in `AppointmentRepository.cs` to use `TimeOnly.MaxValue` and ensure UTC conversion for accurate time range handling. Improved slot booking logic to check if any booked slot falls within the range `[slotStart, slotEnd)`.

Added caching to `GetSlotAsync` in `AppointmentService.cs` to reduce redundant database queries, with a 7-day cache expiration. Implemented cache invalidation when creating or updating appointments to ensure data consistency.

Refactored `GetSlotAsync` to prioritize returning cached slots when available. These changes enhance performance, accuracy, and efficiency in appointment slot management.