### PR TITLE
Improve cache management and appointment creation feedback

### DIFF
--- a/MamaFit.API/Controllers/AppointmentController.cs
+++ b/MamaFit.API/Controllers/AppointmentController.cs
@@ -81,12 +81,12 @@ namespace MamaFit.API.Controllers
         [HttpPost]
         public async Task<IActionResult> Create([FromBody] AppointmentRequestDto requestDto)
         {
-            await _appointmentService.CreateAsync(requestDto);
+            string appointmentId = await _appointmentService.CreateAsync(requestDto);
             return StatusCode(StatusCodes.Status201Created,
                 new ResponseModel<string>(
                     StatusCodes.Status201Created,
                     ApiCodes.CREATED,
-                    null,
+                    appointmentId,
                     "Created appointment successfully!"
                 ));
         }

--- a/MamaFit.Services/ExternalService/Redis/CacheService.cs
+++ b/MamaFit.Services/ExternalService/Redis/CacheService.cs
@@ -117,4 +117,15 @@ public class CacheService : ICacheService
 
         return result.ToList();
     }
+
+    public async Task RemoveByPrefixAsync(string prefix)
+    {
+        string pattern = $"{prefix}*";
+        var keys = await ScanKeysByPatternAsync(pattern);
+        if (keys.Count > 0)
+        {
+            var redisKeys = keys.Select(k => (RedisKey)k).ToArray();
+            await _db.KeyDeleteAsync(redisKeys);
+        }
+    }
 }

--- a/MamaFit.Services/ExternalService/Redis/ICacheService.cs
+++ b/MamaFit.Services/ExternalService/Redis/ICacheService.cs
@@ -16,4 +16,5 @@ public interface ICacheService
     Task KeyExpireAsync(string key, TimeSpan expiry);
     Task RemoveKeyAsync(string key);
     Task<List<string>> ScanKeysByPatternAsync(string pattern);
+    Task RemoveByPrefixAsync(string prefix);
 }

--- a/MamaFit.Services/Interface/IAppointmentService.cs
+++ b/MamaFit.Services/Interface/IAppointmentService.cs
@@ -9,7 +9,7 @@ public interface IAppointmentService
     Task<AppointmentResponseDto> GetByIdAsync(string id);
     Task<PaginatedList<AppointmentResponseDto>> GetByUserId(int index, int pageSize, string? search, AppointmentOrderBy? sortBy);
     Task<List<AppointmentSlotResponseDto>> GetSlotAsync(string branchId, DateOnly date);
-    Task CreateAsync(AppointmentRequestDto requestDto);
+    Task<string> CreateAsync(AppointmentRequestDto requestDto);
     Task UpdateAsync(string id, AppointmentRequestDto requestDto);
     Task DeleteAsync(string id);
     Task CheckInAsync(string id);


### PR DESCRIPTION
Enhanced cache handling by adding `RemoveByPrefixAsync` to `CacheService` and updating related services (`BranchService`, `AppointmentService`) to use it for efficient cache invalidation. Updated `CreateAsync` in `AppointmentService` to return the appointment ID, improving client feedback. Adjusted interfaces (`ICacheService`, `IAppointmentService`) to reflect these changes. Added null handling in `GetSlotAsync` for better validation.